### PR TITLE
updated detekt config

### DIFF
--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -131,9 +131,9 @@ complexity:
     threshold: 60
   LongParameterList:
     active: true
-    functionThreshold: 6
+    functionThreshold: 12
     constructorThreshold: 7
-    ignoreDefaultParameters: false
+    ignoreDefaultParameters: true
     ignoreDataClasses: true
     ignoreAnnotatedParameter: []
   MethodOverloading:
@@ -175,6 +175,7 @@ complexity:
     ignoreDeprecated: false
     ignorePrivate: false
     ignoreOverridden: false
+    ignoreAnnotatedFunctions: ['Preview']
 
 coroutines:
   active: true
@@ -331,7 +332,8 @@ naming:
   FunctionNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
-    functionPattern: '[a-z][a-zA-Z0-9]*'
+    functionPattern: '[a-zA-Z][a-zA-Z0-9]*'
+    ignoreAnnotated: ['Composable']
     excludeClassPattern: '$^'
   FunctionParameterNaming:
     active: true
@@ -364,7 +366,7 @@ naming:
     packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
   TopLevelPropertyNaming:
     active: true
-    constantPattern: '[A-Z][_A-Z0-9]*'
+    constantPattern: '[A-Z][A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:
@@ -615,7 +617,7 @@ style:
       - '1'
       - '2'
     ignoreHashCodeFunction: true
-    ignorePropertyDeclaration: false
+    ignorePropertyDeclaration: true
     ignoreLocalVariableDeclaration: false
     ignoreConstantDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
@@ -738,6 +740,7 @@ style:
   UnusedPrivateMember:
     active: true
     allowedNames: ''
+    ignoreAnnotated: ['Preview']
   UnusedPrivateProperty:
     active: true
     allowedNames: '_|ignored|expected|serialVersionUID'


### PR DESCRIPTION
Updated detekt config with the following changes:
- Increased function threshold for LongParameterList rule.
- Ignored default parameters for LongParameterList rule.
- Increased function threshold for ParameterListWrapping rule.
- Ignored Preview annotated functions for TooManyFunctions rule.
- Updated function pattern for FunctionNaming rule to allow functions starting with a capital letter.
- Ignored Composable annotated functions for FunctionNaming rule.
- Updated constant pattern for TopLevelPropertyNaming rule.
- Ignored property declarations for MagicNumber rule.
- Ignored Preview annotated members for UnusedPrivateMember rule.