### PR TITLE
add kover for code coverage

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,3 +24,19 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+
+    - name: Generate kover coverage report
+      run: ./gradlew koverXmlReport
+
+    - name: Add coverage report to PR
+      id: kover
+      uses: mi-kas/kover-report@v1
+      with:
+        path: |
+          ${{ github.workspace }}/app/build/reports/kover/report.xml
+#          ${{ github.workspace }}/project2/build/reports/kover/report.xml
+        title: Code Coverage
+        update-comment: true
+        min-coverage-overall: 30
+        min-coverage-changed-files: 30
+        coverage-counter-type: LINE

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew assemble
 
     - name: Generate kover coverage report
       run: ./gradlew koverXmlReport
@@ -37,6 +37,6 @@ jobs:
 #          ${{ github.workspace }}/project2/build/reports/kover/report.xml
         title: Code Coverage
         update-comment: true
-        min-coverage-overall: 30
-        min-coverage-changed-files: 30
+        min-coverage-overall: 20
+        min-coverage-changed-files: 20
         coverage-counter-type: LINE

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.kover)
 }
 
 android {
@@ -170,6 +171,28 @@ dependencies {
     testImplementation("androidx.test:core:1.6.1")
     testImplementation("org.robolectric:robolectric:4.11.1") // can't be used because of the current target sdk
     testImplementation("org.hamcrest:hamcrest:2.2")
+}
+
+kover {
+    reports {
+        filters {
+            excludes {
+                annotatedBy("androidx.compose.ui.tooling.preview.Preview")
+            }
+        }
+
+        verify {
+            rule("line-coverage") {
+                minBound(50)
+            }
+            rule("branch-coverage") {
+                minBound(50)
+            }
+        }
+
+        total {
+        }
+    }
 }
 
 java {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -183,10 +183,13 @@ kover {
 
         verify {
             rule("line-coverage") {
-                minBound(50)
+                minBound(20)
             }
             rule("branch-coverage") {
-                minBound(50)
+                minBound(20)
+            }
+            rule("instruction-coverage") {
+                minBound(20)
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.kover) apply false
     alias(libs.plugins.detekt)
 }
 

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -49,3 +49,4 @@ android-application = { id = "com.android.application", version.ref = "android_t
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt"}
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.0-RC" }


### PR DESCRIPTION
This commit introduces kover for code coverage reporting. It includes the necessary dependencies and configuration for generating coverage reports during builds. Additionally, it integrates with GitHub Actions to publish coverage reports on pull requests, enabling tracking and enforcement of code coverage thresholds.