### PR TITLE
Refactor OpenExchangeRatesDownloader to be stateless (fixes #84)

### DIFF
--- a/app/src/main/java/ru/orangesoftware/financisto/rates/OpenExchangeRatesDownloader.kt
+++ b/app/src/main/java/ru/orangesoftware/financisto/rates/OpenExchangeRatesDownloader.kt
@@ -14,12 +14,10 @@ class OpenExchangeRatesDownloader(
     private val clock: Clock
 ) : BaseExchangeRateDownloader(clock) {
 
-    private var cachedJson: JSONObject? = null
-
     override fun getRate(fromCurrency: Currency, toCurrency: Currency): ExchangeRate {
         val exchangeRate = createRate(fromCurrency, toCurrency)
         exchangeRate.safeExecute {
-            val json = getLatestRates()
+            val json = downloadLatestRates()
             if (hasError(json)) {
                 exchangeRate.error = parseErrorMessage(json)
             } else {
@@ -29,16 +27,44 @@ class OpenExchangeRatesDownloader(
         return exchangeRate
     }
 
-    private fun getLatestRates(): JSONObject {
-        cachedJson?.let { return it }
-        
+    override fun getRates(currencies: List<Currency>): List<ExchangeRate> {
+        val rates = mutableListOf<ExchangeRate>()
+        val result = runCatching { downloadLatestRates() }
+
+        val count = currencies.size
+        for (i in 0 until count) {
+            for (j in i + 1 until count) {
+                val fromCurrency = currencies[i]
+                val toCurrency = currencies[j]
+                val exchangeRate = createRate(fromCurrency, toCurrency)
+                
+                result.fold(
+                    onSuccess = { json ->
+                        exchangeRate.safeExecute {
+                            if (hasError(json)) {
+                                exchangeRate.error = parseErrorMessage(json)
+                            } else {
+                                updateRate(json, exchangeRate, fromCurrency, toCurrency)
+                            }
+                        }
+                    },
+                    onFailure = { e ->
+                        exchangeRate.error = "Unable to get exchange rates: ${e.message}"
+                    }
+                )
+                rates.add(exchangeRate)
+            }
+        }
+        return rates
+    }
+
+    private fun downloadLatestRates(): JSONObject {
         if (appId.isNullOrEmpty()) {
             throw RuntimeException("App ID is not set")
         }
         
         logger.i("Downloading latest rates from OpenExchangeRates...")
         val response = httpClientWrapper.getAsJson(getLatestUrl())
-        cachedJson = response
         logger.i("Response: $response")
         return response
     }

--- a/app/src/main/java/ru/orangesoftware/financisto/rates/OpenExchangeRatesDownloader.kt
+++ b/app/src/main/java/ru/orangesoftware/financisto/rates/OpenExchangeRatesDownloader.kt
@@ -32,26 +32,25 @@ class OpenExchangeRatesDownloader(
         val result = runCatching { downloadLatestRates() }
 
         val count = currencies.size
+        val exception = result.exceptionOrNull()
+        val json = result.getOrNull()
+        val jsonError = json?.let { if (hasError(it)) parseErrorMessage(it) else null }
+
         for (i in 0 until count) {
             for (j in i + 1 until count) {
                 val fromCurrency = currencies[i]
                 val toCurrency = currencies[j]
                 val exchangeRate = createRate(fromCurrency, toCurrency)
                 
-                result.fold(
-                    onSuccess = { json ->
-                        exchangeRate.safeExecute {
-                            if (hasError(json)) {
-                                exchangeRate.error = parseErrorMessage(json)
-                            } else {
-                                updateRate(json, exchangeRate, fromCurrency, toCurrency)
-                            }
-                        }
-                    },
-                    onFailure = { e ->
-                        exchangeRate.error = "Unable to get exchange rates: ${e.message}"
+                if (exception != null) {
+                    exchangeRate.error = "Unable to get exchange rates: ${exception.message}"
+                } else if (jsonError != null) {
+                    exchangeRate.error = jsonError
+                } else if (json != null) {
+                    exchangeRate.safeExecute {
+                        updateRate(json, exchangeRate, fromCurrency, toCurrency)
                     }
-                )
+                }
                 rates.add(exchangeRate)
             }
         }

--- a/app/src/test/java/ru/orangesoftware/financisto/rates/OpenExchangeRatesDownloaderTest.kt
+++ b/app/src/test/java/ru/orangesoftware/financisto/rates/OpenExchangeRatesDownloaderTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import ru.orangesoftware.financisto.http.FakeHttpClientWrapper
 import ru.orangesoftware.financisto.utils.FileUtils
 import ru.orangesoftware.financisto.utils.Logger
 import kotlin.time.Clock
@@ -100,6 +101,50 @@ class OpenExchangeRatesDownloaderTest : AbstractRatesDownloaderTest() {
         // then
         assertFalse(downloadedRate.isOk)
         assertEquals("Unable to get exchange rates: Timeout", downloadedRate.errorMessage)
+    }
+
+    @Test
+    fun should_fetch_from_network_only_once_for_getRates() {
+        // given
+        var requestCount = 0
+        val countingClient = object : FakeHttpClientWrapper() {
+            override fun getAsString(url: String): String? {
+                requestCount++
+                return super.getAsString(url)
+            }
+        }
+        countingClient.givenResponse(anyUrl(), FileUtils.testFileAsString("open_exchange_normal_response.json"))
+        
+        val countingOpenRates = OpenExchangeRatesDownloader(countingClient, logger, "MY_APP_ID", clock)
+        
+        // when
+        val rates = countingOpenRates.getRates(currencies("USD", "SGD", "RUB"))
+        
+        // then
+        assertEquals(3, rates.size)
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun should_fetch_from_network_every_time_for_getRate_when_stateless() {
+        // given
+        var requestCount = 0
+        val countingClient = object : FakeHttpClientWrapper() {
+            override fun getAsString(url: String): String? {
+                requestCount++
+                return super.getAsString(url)
+            }
+        }
+        countingClient.givenResponse(anyUrl(), FileUtils.testFileAsString("open_exchange_normal_response.json"))
+        
+        val countingOpenRates = OpenExchangeRatesDownloader(countingClient, logger, "MY_APP_ID", clock)
+        
+        // when
+        countingOpenRates.getRate(currency("USD"), currency("SGD"))
+        countingOpenRates.getRate(currency("USD"), currency("RUB"))
+        
+        // then
+        assertEquals(2, requestCount)
     }
 
     override fun givenResponseFromWebService(url: String, fileName: String) {


### PR DESCRIPTION
### Title
Refactor OpenExchangeRatesDownloader to be stateless (fixes #84)

### Description
This PR refactors `OpenExchangeRatesDownloader` to make it stateless, improving thread safety and testability as suggested in the discussion.

### Key Changes
* Removed the mutable `cachedJson` instance property from `OpenExchangeRatesDownloader`.
* Renamed `getLatestRates()` to `downloadLatestRates()` to better indicate its lack of instance caching.
* Overrode `getRates(currencies)` to fetch the JSON from the API once per batch and process all pairs locally, keeping the downloader stateless while preserving network efficiency.
* Added unit tests to `OpenExchangeRatesDownloaderTest` to verify both the stateless nature of `getRate` (separate calls trigger separate network requests) and the correct local caching behavior in `getRates` (single network request for a batch of currencies).

### Verification
* Ran `./gradlew test` (all tests passed).
* Verified the specific test cases in `OpenExchangeRatesDownloaderTest` pass successfully.
* Ran `./gradlew assembleDebug` (build compiled and assembled successfully).

### Closes
Closes #84