### PR TITLE
refactor(db): modernise database mappers and fix column prefix crashes

### DIFF
--- a/app/src/main/java/ru/orangesoftware/financisto/activity/AccountWidget.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/activity/AccountWidget.java
@@ -11,6 +11,7 @@
 package ru.orangesoftware.financisto.activity;
 
 import static android.appwidget.AppWidgetManager.INVALID_APPWIDGET_ID;
+import static ru.orangesoftware.financisto.db.DatabaseMappersKt.toAccount;
 import static ru.orangesoftware.financisto.utils.EnumUtils.selectEnum;
 
 import android.app.PendingIntent;
@@ -41,7 +42,6 @@ import ru.orangesoftware.financisto.model.ElectronicPaymentType;
 import ru.orangesoftware.financisto.utils.Logger;
 import ru.orangesoftware.financisto.utils.MyPreferences;
 import ru.orangesoftware.financisto.utils.Utils;
-import ru.orangesoftware.orb.EntityManager;
 
 public class AccountWidget extends AppWidgetProvider {
 
@@ -228,13 +228,13 @@ public class AccountWidget extends AppWidgetProvider {
                     logger.d("buildUpdateForNextAccount " + widgetId + " -> " + accountId);
                     if (count == 1 || accountId == -1) {
                         if (c.moveToNext()) {
-                            Account a = EntityManager.loadFromCursor(c, Account.class);
+                            Account a = toAccount(c, db);
                             return updateWidgetFromAccount(context, widgetId, layoutId, providerClass, a);
                         }
                     } else {
                         boolean found = false;
                         while (c.moveToNext()) {
-                            Account a = EntityManager.loadFromCursor(c, Account.class);
+                             Account a = toAccount(c, db);
                             if (a.id == accountId) {
                                 found = true;
                                 logger.d("buildUpdateForNextAccount found -> " + accountId);
@@ -246,7 +246,7 @@ public class AccountWidget extends AppWidgetProvider {
                             }
                         }
                         c.moveToFirst();
-                        Account a = EntityManager.loadFromCursor(c, Account.class);
+                        Account a = toAccount(c, db);
                         logger.d("buildUpdateForNextAccount not found, taking the first one -> " + a.id);
                         return updateWidgetFromAccount(context, widgetId, layoutId, providerClass, a);
                     }

--- a/app/src/main/java/ru/orangesoftware/financisto/activity/QifImportActivity.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/activity/QifImportActivity.java
@@ -42,8 +42,9 @@ public class QifImportActivity extends AbstractImportActivity implements Activit
         Spinner currencySpinner = findViewById(R.id.spinnerCurrency);
         Cursor currencyCursor = db.getAllCurrencies("name");
         startManagingCursor(currencyCursor);
+        String columnName = currencyCursor.getColumnIndex("name") != -1 ? "name" : "e_name";
         SimpleCursorAdapter currencyAdapter = new SimpleCursorAdapter(this, R.layout.themed_spinner_item, currencyCursor,
-                new String[]{"e_name"}, new int[]{android.R.id.text1});
+                new String[]{columnName}, new int[]{android.R.id.text1});
         currencyAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         currencySpinner.setAdapter(currencyAdapter);
 

--- a/app/src/main/java/ru/orangesoftware/financisto/adapter/AccountListAdapter2.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/adapter/AccountListAdapter2.java
@@ -25,7 +25,9 @@ import java.text.DateFormat;
 import java.util.Date;
 
 import ru.orangesoftware.financisto.R;
+import ru.orangesoftware.financisto.app.DependenciesHolder;
 import ru.orangesoftware.financisto.datetime.DateUtils;
+import ru.orangesoftware.financisto.db.DatabaseAdapter;
 import ru.orangesoftware.financisto.model.Account;
 import ru.orangesoftware.financisto.model.AccountType;
 import ru.orangesoftware.financisto.model.CardIssuer;
@@ -35,12 +37,14 @@ import ru.orangesoftware.financisto.utils.Utils;
 
 public class AccountListAdapter2 extends ResourceCursorAdapter {
 
+    private final DatabaseAdapter db;
     private final Utils u;
     private final DateFormat df;
     private final boolean isShowAccountLastTransactionDate;
 
     public AccountListAdapter2(Context context, Cursor c) {
         super(context, R.layout.account_list_item, c);
+        this.db = new DependenciesHolder().getDatabaseAdapter();
         this.u = new Utils(context);
         this.df = DateUtils.getShortDateFormat(context);
         this.isShowAccountLastTransactionDate = MyPreferences.isShowAccountLastTransactionDate(context);
@@ -54,7 +58,7 @@ public class AccountListAdapter2 extends ResourceCursorAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
-        Account a = toAccount(cursor, new ru.orangesoftware.financisto.app.DependenciesHolder().getDatabaseAdapter());
+        Account a = toAccount(cursor, db);
         AccountListItemHolder v = (AccountListItemHolder) view.getTag();
 
         v.centerView.setText(a.title);

--- a/app/src/main/java/ru/orangesoftware/financisto/adapter/AccountListAdapter2.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/adapter/AccountListAdapter2.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package ru.orangesoftware.financisto.adapter;
 
+import static ru.orangesoftware.financisto.db.DatabaseMappersKt.toAccount;
+
 import android.content.Context;
 import android.database.Cursor;
 import android.view.View;
@@ -30,7 +32,6 @@ import ru.orangesoftware.financisto.model.CardIssuer;
 import ru.orangesoftware.financisto.model.ElectronicPaymentType;
 import ru.orangesoftware.financisto.utils.MyPreferences;
 import ru.orangesoftware.financisto.utils.Utils;
-import ru.orangesoftware.orb.EntityManager;
 
 public class AccountListAdapter2 extends ResourceCursorAdapter {
 
@@ -53,7 +54,7 @@ public class AccountListAdapter2 extends ResourceCursorAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
-        Account a = EntityManager.loadFromCursor(cursor, Account.class);
+        Account a = toAccount(cursor, new ru.orangesoftware.financisto.app.DependenciesHolder().getDatabaseAdapter());
         AccountListItemHolder v = (AccountListItemHolder) view.getTag();
 
         v.centerView.setText(a.title);
@@ -137,8 +138,5 @@ public class AccountListAdapter2 extends ResourceCursorAdapter {
             view.setTag(v);
             return view;
         }
-
     }
-
-
 }

--- a/app/src/main/java/ru/orangesoftware/financisto/adapter/CurrencyListAdapter.kt
+++ b/app/src/main/java/ru/orangesoftware/financisto/adapter/CurrencyListAdapter.kt
@@ -2,12 +2,10 @@ package ru.orangesoftware.financisto.adapter
 
 import android.content.Context
 import android.database.Cursor
-
 import ru.orangesoftware.financisto.R
 import ru.orangesoftware.financisto.db.DatabaseAdapter
-import ru.orangesoftware.financisto.model.Currency
+import ru.orangesoftware.financisto.db.toCurrency
 import ru.orangesoftware.financisto.utils.Utils
-import ru.orangesoftware.orb.EntityManager
 
 class CurrencyListAdapter(
 	db: DatabaseAdapter,
@@ -15,7 +13,7 @@ class CurrencyListAdapter(
 	c: Cursor
 ) : AbstractGenericListAdapter(db, context, c) {
 	override fun bindView(v: GenericViewHolder?, context: Context?, cursor: Cursor?) {
-		val c = EntityManager.loadFromCursor(cursor, Currency::class.java)
+		val c = cursor?.toCurrency() ?: return
 		v?.lineView?.text = c.title
 		v?.numberView?.text = c.name
 		v?.amountView?.text = Utils.amountToString(c, 100000)

--- a/app/src/main/java/ru/orangesoftware/financisto/db/DatabaseMappers.kt
+++ b/app/src/main/java/ru/orangesoftware/financisto/db/DatabaseMappers.kt
@@ -931,8 +931,10 @@ fun MyEntityManager.getAllAccountsCursor(isActiveOnly: Boolean, includeAccounts:
     
     val orderBy = StringBuilder("is_active DESC, ")
     val colName = when (sortOrder.property) {
-        "sortOrder" -> "sort_order"
-        "totalAmount" -> "total_amount"
+        "sortOrder", "sort_order" -> "sort_order"
+        "totalAmount", "total_amount" -> "total_amount"
+        "creationDate", "creation_date" -> "creation_date"
+        "lastTransactionDate", "last_transaction_date" -> "last_transaction_date"
         else -> sortOrder.property
     }
     orderBy.append(colName).append(if (sortOrder.asc) " ASC" else " DESC")

--- a/app/src/main/java/ru/orangesoftware/financisto/db/DatabaseMappers.kt
+++ b/app/src/main/java/ru/orangesoftware/financisto/db/DatabaseMappers.kt
@@ -1,0 +1,887 @@
+package ru.orangesoftware.financisto.db
+
+import android.content.ContentValues
+import android.database.Cursor
+import ru.orangesoftware.financisto.model.Account
+import ru.orangesoftware.financisto.model.Budget
+import ru.orangesoftware.financisto.model.Category
+import ru.orangesoftware.financisto.model.Currency
+import ru.orangesoftware.financisto.model.MyLocation
+import ru.orangesoftware.financisto.model.Payee
+import ru.orangesoftware.financisto.model.Project
+import ru.orangesoftware.financisto.model.SmsTemplate
+import ru.orangesoftware.financisto.model.SymbolFormat
+import ru.orangesoftware.financisto.model.SystemAttribute
+import ru.orangesoftware.financisto.model.Transaction
+import ru.orangesoftware.financisto.model.TransactionAttributeInfo
+import ru.orangesoftware.financisto.model.TransactionInfo
+import ru.orangesoftware.financisto.model.TransactionStatus
+import ru.orangesoftware.financisto.utils.CurrencyCache
+import ru.orangesoftware.financisto.utils.MyPreferences
+import ru.orangesoftware.financisto.utils.StringUtil
+import ru.orangesoftware.orb.Sort
+
+// Safe Cursor Helpers
+fun Cursor.getStringSafe(columnName: String): String? {
+    val idx = getColumnIndex(columnName)
+    return if (idx >= 0 && !isNull(idx)) getString(idx) else null
+}
+
+fun Cursor.getLongSafe(columnName: String, defaultValue: Long = 0L): Long {
+    val idx = getColumnIndex(columnName)
+    return if (idx >= 0 && !isNull(idx)) getLong(idx) else defaultValue
+}
+
+fun Cursor.getIntSafe(columnName: String, defaultValue: Int = 0): Int {
+    val idx = getColumnIndex(columnName)
+    return if (idx >= 0 && !isNull(idx)) getInt(idx) else defaultValue
+}
+
+fun Cursor.getFloatSafe(columnName: String, defaultValue: Float = 0f): Float {
+    val idx = getColumnIndex(columnName)
+    return if (idx >= 0 && !isNull(idx)) getFloat(idx) else defaultValue
+}
+
+fun Cursor.getDoubleSafe(columnName: String, defaultValue: Double = 0.0): Double {
+    val idx = getColumnIndex(columnName)
+    return if (idx >= 0 && !isNull(idx)) getDouble(idx) else defaultValue
+}
+
+fun Cursor.getBooleanSafe(columnName: String, defaultValue: Boolean = false): Boolean {
+    val idx = getColumnIndex(columnName)
+    return if (idx >= 0 && !isNull(idx)) getInt(idx) != 0 else defaultValue
+}
+
+// -------------------------------------------------------------------
+// Entity Mappers from Cursor
+// -------------------------------------------------------------------
+
+fun Cursor.toAccount(em: MyEntityManager): Account {
+    val a = Account()
+    a.id = getLongSafe("_id", getLongSafe("e__id", -1L))
+    a.title = getStringSafe("title") ?: getStringSafe("e_title")
+    a.creationDate = getLongSafe("creation_date", getLongSafe("e_creation_date", 0L))
+    a.lastTransactionDate = getLongSafe("last_transaction_date", getLongSafe("e_last_transaction_date", 0L))
+    
+    val currencyId = getLongSafe("currency_id", getLongSafe("e_currency_id", 0L))
+    a.currency = if (currencyId > 0) CurrencyCache.getCurrency(em, currencyId) else null
+    
+    a.type = getStringSafe("type") ?: getStringSafe("e_type")
+    a.cardIssuer = getStringSafe("card_issuer") ?: getStringSafe("e_card_issuer")
+    a.issuer = getStringSafe("issuer") ?: getStringSafe("e_issuer")
+    a.number = getStringSafe("number") ?: getStringSafe("e_number")
+    a.totalAmount = getLongSafe("total_amount", getLongSafe("e_total_amount", 0L))
+    a.limitAmount = getLongSafe("total_limit", getLongSafe("e_total_limit", 0L))
+    a.sortOrder = getIntSafe("sort_order", getIntSafe("e_sort_order", 0))
+    a.isIncludeIntoTotals = getBooleanSafe("is_include_into_totals", getBooleanSafe("e_is_include_into_totals", true))
+    a.lastAccountId = getLongSafe("last_account_id", getLongSafe("e_last_account_id", 0L))
+    a.lastCategoryId = getLongSafe("last_category_id", getLongSafe("e_last_category_id", 0L))
+    a.closingDay = getIntSafe("closing_day", getIntSafe("e_closing_day", 0))
+    a.paymentDay = getIntSafe("payment_day", getIntSafe("e_payment_day", 0))
+    a.note = getStringSafe("note") ?: getStringSafe("e_note")
+    a.isActive = getBooleanSafe("is_active", getBooleanSafe("e_is_active", true))
+    return a
+}
+
+fun Cursor.toPayee(): Payee {
+    val p = Payee()
+    p.id = getLongSafe("_id", getLongSafe("e__id", -1L))
+    p.title = getStringSafe("title") ?: getStringSafe("e_title")
+    p.lastCategoryId = getLongSafe("last_category_id", getLongSafe("e_last_category_id", 0L))
+    p.sortOrder = getLongSafe("sort_order", getLongSafe("e_sort_order", 0L))
+    p.isActive = getBooleanSafe("is_active", getBooleanSafe("e_is_active", true))
+    return p
+}
+
+fun Cursor.toProject(): Project {
+    val p = Project()
+    p.id = getLongSafe("_id", getLongSafe("e__id", -1L))
+    p.title = getStringSafe("title") ?: getStringSafe("e_title")
+    p.sortOrder = getLongSafe("sort_order", getLongSafe("e_sort_order", 0L))
+    p.isActive = getBooleanSafe("is_active", getBooleanSafe("e_is_active", true))
+    return p
+}
+
+fun Cursor.toMyLocation(): MyLocation {
+    val loc = MyLocation()
+    loc.id = getLongSafe("_id", getLongSafe("e__id", -1L))
+    loc.title = getStringSafe("title") ?: getStringSafe("e_title")
+    loc.provider = getStringSafe("provider") ?: getStringSafe("e_provider")
+    loc.accuracy = getFloatSafe("accuracy", getFloatSafe("e_accuracy", 0f))
+    loc.longitude = getDoubleSafe("longitude", getDoubleSafe("e_longitude", 0.0))
+    loc.latitude = getDoubleSafe("latitude", getDoubleSafe("e_latitude", 0.0))
+    loc.resolvedAddress = getStringSafe("resolved_address") ?: getStringSafe("e_resolved_address")
+    loc.dateTime = getLongSafe("datetime", getLongSafe("e_datetime", 0L))
+    loc.count = getIntSafe("count", getIntSafe("e_count", 0))
+    loc.sortOrder = getLongSafe("sort_order", getLongSafe("e_sort_order", 0L))
+    loc.isActive = getBooleanSafe("is_active", getBooleanSafe("e_is_active", true))
+    return loc
+}
+
+fun Cursor.toBudget(em: MyEntityManager): Budget {
+    val b = Budget()
+    b.id = getLongSafe("_id", getLongSafe("e__id", -1L))
+    b.title = getStringSafe("title") ?: getStringSafe("e_title")
+    b.categories = getStringSafe("category_id") ?: getStringSafe("e_category_id")
+    b.projects = getStringSafe("project_id") ?: getStringSafe("e_project_id")
+    b.currencyId = getLongSafe("currency_id", getLongSafe("e_currency_id", -1L))
+    
+    val budgetCurrencyId = getLongSafe("budget_currency_id", getLongSafe("e_budget_currency_id", 0L))
+    b.currency = if (budgetCurrencyId > 0) CurrencyCache.getCurrency(em, budgetCurrencyId) else null
+    
+    val budgetAccountId = getLongSafe("budget_account_id", getLongSafe("e_budget_account_id", 0L))
+    b.account = if (budgetAccountId > 0) em.getAccount(budgetAccountId) else null
+    
+    b.amount = getLongSafe("amount", getLongSafe("e_amount", 0L))
+    b.includeSubcategories = getBooleanSafe("include_subcategories", getBooleanSafe("e_include_subcategories", false))
+    b.expanded = getBooleanSafe("expanded", getBooleanSafe("e_expanded", false))
+    b.includeCredit = getBooleanSafe("include_credit", getBooleanSafe("e_include_credit", true))
+    b.startDate = getLongSafe("start_date", getLongSafe("e_start_date", 0L))
+    b.endDate = getLongSafe("end_date", getLongSafe("e_end_date", 0L))
+    b.recur = getStringSafe("recur") ?: getStringSafe("e_recur")
+    b.recurNum = getLongSafe("recur_num", getLongSafe("e_recur_num", 0L))
+    b.isCurrent = getBooleanSafe("is_current", getBooleanSafe("e_is_current", false))
+    b.parentBudgetId = getLongSafe("parent_budget_id", getLongSafe("e_parent_budget_id", 0L))
+    b.updatedOn = getLongSafe("updated_on", getLongSafe("e_updated_on", 0L))
+    b.remoteKey = getStringSafe("remote_key") ?: getStringSafe("e_remote_key")
+    b.sortOrder = getLongSafe("sort_order", getLongSafe("e_sort_order", 0L))
+    return b
+}
+
+fun Cursor.toCurrency(): Currency {
+    val cur = Currency()
+    cur.id = getLongSafe("_id", getLongSafe("e__id", -1L))
+    cur.title = getStringSafe("title") ?: getStringSafe("e_title")
+    cur.name = getStringSafe("name") ?: getStringSafe("e_name")
+    cur.symbol = getStringSafe("symbol") ?: getStringSafe("e_symbol")
+    val symbolFormatStr = getStringSafe("symbol_format") ?: getStringSafe("e_symbol_format")
+    cur.symbolFormat = if (symbolFormatStr != null) {
+        try { SymbolFormat.valueOf(symbolFormatStr) } catch (e: Exception) { SymbolFormat.RS }
+    } else {
+        SymbolFormat.RS
+    }
+    cur.isDefault = getBooleanSafe("is_default", getBooleanSafe("e_is_default", false))
+    cur.decimals = getIntSafe("decimals", getIntSafe("e_decimals", 2))
+    cur.decimalSeparator = getStringSafe("decimal_separator") ?: getStringSafe("e_decimal_separator")
+    cur.groupSeparator = getStringSafe("group_separator") ?: getStringSafe("e_group_separator")
+    cur.sortOrder = getLongSafe("sort_order", getLongSafe("e_sort_order", 0L))
+    cur.isActive = getBooleanSafe("is_active", getBooleanSafe("e_is_active", true))
+    return cur
+}
+
+fun Cursor.toTransaction(): Transaction {
+    val t = Transaction()
+    t.id = getLongSafe("_id", getLongSafe("e__id", -1L))
+    t.parentId = getLongSafe("parent_id", getLongSafe("e_parent_id", 0L))
+    t.categoryId = getLongSafe("category_id", getLongSafe("e_category_id", 0L))
+    t.projectId = getLongSafe("project_id", getLongSafe("e_project_id", 0L))
+    t.locationId = getLongSafe("location_id", getLongSafe("e_location_id", 0L))
+    t.fromAccountId = getLongSafe("from_account_id", getLongSafe("e_from_account_id", 0L))
+    t.toAccountId = getLongSafe("to_account_id", getLongSafe("e_to_account_id", 0L))
+    t.payeeId = getLongSafe("payee_id", getLongSafe("e_payee_id", 0L))
+    t.blobKey = getStringSafe("blob_key") ?: getStringSafe("e_blob_key")
+    t.originalCurrencyId = getLongSafe("original_currency_id", getLongSafe("e_original_currency_id", 0L))
+    t.dateTime = getLongSafe("datetime", getLongSafe("e_datetime", 0L))
+    t.provider = getStringSafe("provider") ?: getStringSafe("e_provider")
+    t.accuracy = getFloatSafe("accuracy", getFloatSafe("e_accuracy", 0f))
+    t.longitude = getDoubleSafe("longitude", getDoubleSafe("e_longitude", 0.0))
+    t.latitude = getDoubleSafe("latitude", getDoubleSafe("e_latitude", 0.0))
+    t.note = getStringSafe("note") ?: getStringSafe("e_note")
+    t.originalFromAmount = getLongSafe("original_from_amount", getLongSafe("e_original_from_amount", 0L))
+    t.fromAmount = getLongSafe("from_amount", getLongSafe("e_from_amount", 0L))
+    t.toAmount = getLongSafe("to_amount", getLongSafe("e_to_amount", 0L))
+    t.isTemplate = getIntSafe("is_template", getIntSafe("e_is_template", 0))
+    t.templateName = getStringSafe("template_name") ?: getStringSafe("e_template_name")
+    t.recurrence = getStringSafe("recurrence") ?: getStringSafe("e_recurrence")
+    t.notificationOptions = getStringSafe("notification_options") ?: getStringSafe("e_notification_options")
+    val statusStr = getStringSafe("status") ?: getStringSafe("e_status")
+    t.status = if (statusStr != null) {
+        try { TransactionStatus.valueOf(statusStr) } catch (e: Exception) { TransactionStatus.UR }
+    } else {
+        TransactionStatus.UR
+    }
+    t.attachedPicture = getStringSafe("attached_picture") ?: getStringSafe("e_attached_picture")
+    t.isCCardPayment = getIntSafe("is_ccard_payment", getIntSafe("e_is_ccard_payment", 0))
+    t.lastRecurrence = getLongSafe("last_recurrence", getLongSafe("e_last_recurrence", 0L))
+    t.updatedOn = getLongSafe("updated_on", getLongSafe("e_updated_on", 0L))
+    t.remoteKey = getStringSafe("remote_key") ?: getStringSafe("e_remote_key")
+    return t
+}
+
+fun Cursor.toTransactionAttributeInfo(): TransactionAttributeInfo {
+    val info = TransactionAttributeInfo()
+    info.transactionId = getLongSafe("_id", getLongSafe("e__id", getLongSafe("transaction_id", -1L)))
+    info.attributeId = getLongSafe("attribute_id", getLongSafe("e_attribute_id", -1L))
+    info.type = getIntSafe("attribute_type", getIntSafe("e_attribute_type", 0))
+    info.name = getStringSafe("attribute_name") ?: getStringSafe("e_attribute_name")
+    info.value = getStringSafe("attribute_value") ?: getStringSafe("e_attribute_value")
+    info.listValues = getStringSafe("attribute_list_values") ?: getStringSafe("e_attribute_list_values")
+    return info
+}
+
+fun Cursor.toTransactionInfo(em: MyEntityManager): TransactionInfo {
+    val info = TransactionInfo()
+    info.id = getLongSafe("_id", getLongSafe("e__id", -1L))
+    info.parentId = getLongSafe("parent_id", getLongSafe("e_parent_id", 0L))
+    info.dateTime = getLongSafe("datetime", getLongSafe("e_datetime", 0L))
+    info.provider = getStringSafe("provider") ?: getStringSafe("e_provider")
+    info.accuracy = getFloatSafe("accuracy", getFloatSafe("e_accuracy", 0f))
+    info.longitude = getDoubleSafe("longitude", getDoubleSafe("e_longitude", 0.0))
+    info.latitude = getDoubleSafe("latitude", getDoubleSafe("e_latitude", 0.0))
+    info.note = getStringSafe("note") ?: getStringSafe("e_note")
+    info.originalFromAmount = getLongSafe("original_from_amount", getLongSafe("e_original_from_amount", 0L))
+    info.fromAmount = getLongSafe("from_amount", getLongSafe("e_from_amount", 0L))
+    info.toAmount = getLongSafe("to_amount", getLongSafe("e_to_amount", 0L))
+    info.isTemplate = getIntSafe("is_template", getIntSafe("e_is_template", 0))
+    info.templateName = getStringSafe("template_name") ?: getStringSafe("e_template_name")
+    info.recurrence = getStringSafe("recurrence") ?: getStringSafe("e_recurrence")
+    info.notificationOptions = getStringSafe("notification_options") ?: getStringSafe("e_notification_options")
+    val statusStr = getStringSafe("status") ?: getStringSafe("e_status")
+    info.status = if (statusStr != null) {
+        try { TransactionStatus.valueOf(statusStr) } catch (e: Exception) { TransactionStatus.UR }
+    } else {
+        TransactionStatus.UR
+    }
+    info.attachedPicture = getStringSafe("attached_picture") ?: getStringSafe("e_attached_picture")
+    info.isCCardPayment = getIntSafe("is_ccard_payment", getIntSafe("e_is_ccard_payment", 0))
+    info.lastRecurrence = getLongSafe("last_recurrence", getLongSafe("e_last_recurrence", 0L))
+    info.updatedOn = getLongSafe("updated_on", getLongSafe("e_updated_on", 0L))
+    info.remoteKey = getStringSafe("remote_key") ?: getStringSafe("e_remote_key")
+
+    // Fetch mapped entities
+    val fromAccountId = getLongSafe("from_account_id", getLongSafe("e_from_account_id", 0L))
+    info.fromAccount = if (fromAccountId > 0) em.getAccount(fromAccountId) else null
+    val toAccountId = getLongSafe("to_account_id", getLongSafe("e_to_account_id", 0L))
+    info.toAccount = if (toAccountId > 0) em.getAccount(toAccountId) else null
+    val categoryId = getLongSafe("category_id", getLongSafe("e_category_id", 0L))
+    info.category = em.getCategory(categoryId) ?: Category.noCategory()
+    val projectId = getLongSafe("project_id", getLongSafe("e_project_id", 0L))
+    info.project = if (projectId > 0) em.getProject(projectId) else null
+    val locationId = getLongSafe("location_id", getLongSafe("e_location_id", 0L))
+    info.location = if (locationId > 0) em.getLocation(locationId) else null
+    val originalCurrencyId = getLongSafe("original_currency_id", getLongSafe("e_original_currency_id", 0L))
+    info.originalCurrency = if (originalCurrencyId > 0) CurrencyCache.getCurrency(em, originalCurrencyId) else null
+    val payeeId = getLongSafe("payee_id", getLongSafe("e_payee_id", 0L))
+    info.payee = if (payeeId > 0) em.getPayee(payeeId) else null
+    
+    return info
+}
+
+// -------------------------------------------------------------------
+// ContentValues conversions
+// -------------------------------------------------------------------
+
+fun Account.toValues(): ContentValues {
+    val cv = ContentValues()
+    cv.put("title", title)
+    cv.put("creation_date", creationDate)
+    cv.put("last_transaction_date", lastTransactionDate)
+    cv.put("currency_id", currency?.id ?: 0L)
+    cv.put("type", type)
+    cv.put("card_issuer", cardIssuer)
+    cv.put("issuer", issuer)
+    cv.put("number", number)
+    cv.put("total_amount", totalAmount)
+    cv.put("total_limit", limitAmount)
+    cv.put("sort_order", sortOrder)
+    cv.put("is_include_into_totals", if (isIncludeIntoTotals) 1 else 0)
+    cv.put("last_account_id", lastAccountId)
+    cv.put("last_category_id", lastCategoryId)
+    cv.put("closing_day", closingDay)
+    cv.put("payment_day", paymentDay)
+    cv.put("note", note)
+    cv.put("is_active", if (isActive) 1 else 0)
+    return cv
+}
+
+fun Payee.toValues(): ContentValues {
+    val cv = ContentValues()
+    cv.put("title", title)
+    cv.put("last_category_id", lastCategoryId)
+    cv.put("sort_order", sortOrder)
+    cv.put("is_active", if (isActive) 1 else 0)
+    return cv
+}
+
+fun Project.toValues(): ContentValues {
+    val cv = ContentValues()
+    cv.put("title", title)
+    cv.put("sort_order", sortOrder)
+    cv.put("is_active", if (isActive) 1 else 0)
+    return cv
+}
+
+fun MyLocation.toValues(): ContentValues {
+    val cv = ContentValues()
+    cv.put("title", title)
+    cv.put("name", title)
+    cv.put("provider", provider)
+    cv.put("accuracy", accuracy)
+    cv.put("longitude", longitude)
+    cv.put("latitude", latitude)
+    cv.put("resolved_address", resolvedAddress)
+    cv.put("datetime", dateTime)
+    cv.put("count", count)
+    cv.put("sort_order", sortOrder)
+    cv.put("is_active", if (isActive) 1 else 0)
+    return cv
+}
+
+fun Budget.toValues(): ContentValues {
+    val cv = ContentValues()
+    cv.put("title", title)
+    cv.put("category_id", categories)
+    cv.put("project_id", projects)
+    cv.put("currency_id", currencyId)
+    cv.put("budget_currency_id", currency?.id ?: 0L)
+    cv.put("budget_account_id", account?.id ?: 0L)
+    cv.put("amount", amount)
+    cv.put("include_subcategories", if (includeSubcategories) 1 else 0)
+    cv.put("expanded", if (expanded) 1 else 0)
+    cv.put("include_credit", if (includeCredit) 1 else 0)
+    cv.put("start_date", startDate)
+    cv.put("end_date", endDate)
+    cv.put("recur", recur)
+    cv.put("recur_num", recurNum)
+    cv.put("is_current", if (isCurrent) 1 else 0)
+    cv.put("parent_budget_id", parentBudgetId)
+    cv.put("remote_key", remoteKey)
+    cv.put("sort_order", sortOrder)
+    return cv
+}
+
+fun Currency.toValues(): ContentValues {
+    val cv = ContentValues()
+    cv.put("title", title)
+    cv.put("name", name)
+    cv.put("symbol", symbol)
+    cv.put("symbol_format", symbolFormat.name)
+    cv.put("is_default", if (isDefault) 1 else 0)
+    cv.put("decimals", decimals)
+    cv.put("decimal_separator", decimalSeparator)
+    cv.put("group_separator", groupSeparator)
+    cv.put("sort_order", sortOrder)
+    cv.put("is_active", if (isActive) 1 else 0)
+    return cv
+}
+
+fun SmsTemplate.toValues(): ContentValues {
+    val cv = ContentValues()
+    cv.put("title", title)
+    cv.put("template", template)
+    cv.put("category_id", categoryId)
+    cv.put("account_id", accountId)
+    cv.put("is_income", if (isIncome) 1 else 0)
+    cv.put("sort_order", sortOrder)
+    cv.put("is_active", if (isActive) 1 else 0)
+    return cv
+}
+
+// -------------------------------------------------------------------
+// SQL executions via Extensions (delegated from DatabaseAdapter/MyEntityManager)
+// -------------------------------------------------------------------
+
+fun MyEntityManager.getTableName(clazz: Class<*>): String? {
+    return when (clazz) {
+        Account::class.java -> DatabaseHelper.ACCOUNT_TABLE
+        Payee::class.java -> DatabaseHelper.PAYEE_TABLE
+        Project::class.java -> DatabaseHelper.PROJECT_TABLE
+        MyLocation::class.java -> DatabaseHelper.LOCATIONS_TABLE
+        Category::class.java -> DatabaseHelper.CATEGORY_TABLE
+        Currency::class.java -> DatabaseHelper.CURRENCY_TABLE
+        SmsTemplate::class.java -> DatabaseHelper.SMS_TEMPLATES_TABLE
+        Budget::class.java -> DatabaseHelper.BUDGET_TABLE
+        Transaction::class.java -> DatabaseHelper.TRANSACTION_TABLE
+        else -> null
+    }
+}
+
+fun MyEntityManager.queryEntitiesCursor(
+    tableName: String,
+    include0: Boolean,
+    onlyActive: Boolean,
+    filter: String?,
+    sort: Array<out Sort>?
+): Cursor {
+    val selection = StringBuilder()
+    val selectionArgs = mutableListOf<String>()
+    
+    selection.append(if (include0) "_id >= 0" else "_id > 0")
+    
+    if (onlyActive) {
+        selection.append(" AND is_active = 1")
+    }
+    
+    if (!filter.isNullOrBlank()) {
+        val titleLike = filter.replace(" ", "%")
+        selection.append(" AND (title LIKE ? OR title LIKE ?)")
+        selectionArgs.add("%$titleLike%")
+        selectionArgs.add("%${StringUtil.capitalize(titleLike)}%")
+    }
+    
+    val order = sort?.takeIf { it.isNotEmpty() }?.joinToString(", ") { s ->
+        val col = if (s.field == "sortOrder" || s.field == "sort_order") "sort_order" else s.field
+        "$col ${if (s.asc) "ASC" else "DESC"}"
+    } ?: "title ASC"
+    
+    return db().query(
+        tableName,
+        null,
+        selection.toString(),
+        if (selectionArgs.isNotEmpty()) selectionArgs.toTypedArray() else null,
+        null,
+        null,
+        order
+    )
+}
+
+// Lists
+
+fun MyEntityManager.getAccountsList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<Account> {
+    val list = ArrayList<Account>()
+    queryEntitiesCursor(DatabaseHelper.ACCOUNT_TABLE, include0, onlyActive, filter, sort).use { c ->
+        while (c.moveToNext()) {
+            list.add(c.toAccount(this))
+        }
+    }
+    return list
+}
+
+fun MyEntityManager.getPayeesList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<Payee> {
+    val list = ArrayList<Payee>()
+    queryEntitiesCursor(DatabaseHelper.PAYEE_TABLE, include0, onlyActive, filter, sort).use { c ->
+        while (c.moveToNext()) {
+            list.add(c.toPayee())
+        }
+    }
+    return list
+}
+
+fun MyEntityManager.getProjectsList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<Project> {
+    val list = ArrayList<Project>()
+    queryEntitiesCursor(DatabaseHelper.PROJECT_TABLE, include0, onlyActive, filter, sort).use { c ->
+        while (c.moveToNext()) {
+            list.add(c.toProject())
+        }
+    }
+    return list
+}
+
+fun MyEntityManager.getLocationsList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<MyLocation> {
+    val list = ArrayList<MyLocation>()
+    queryEntitiesCursor(DatabaseHelper.LOCATIONS_TABLE, include0, onlyActive, filter, sort).use { c ->
+        while (c.moveToNext()) {
+            list.add(c.toMyLocation())
+        }
+    }
+    return list
+}
+
+fun MyEntityManager.getCategoriesList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<Category> {
+    val list = ArrayList<Category>()
+    queryEntitiesCursor(DatabaseHelper.CATEGORY_TABLE, include0, onlyActive, filter, sort).use { c ->
+        while (c.moveToNext()) {
+            list.add(Category.formCursor(c))
+        }
+    }
+    return list
+}
+
+fun MyEntityManager.getCurrenciesList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<Currency> {
+    val list = ArrayList<Currency>()
+    queryEntitiesCursor(DatabaseHelper.CURRENCY_TABLE, include0, onlyActive, filter, sort).use { c ->
+        while (c.moveToNext()) {
+            list.add(c.toCurrency())
+        }
+    }
+    return list
+}
+
+// Standard typed gets
+
+@JvmName("getAccount")
+fun MyEntityManager.getAccount(id: Long): Account? {
+    db().query(DatabaseHelper.ACCOUNT_TABLE, null, "_id=?", arrayOf(id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return c.toAccount(this)
+    }
+    return null
+}
+
+@JvmName("getPayee")
+fun MyEntityManager.getPayee(id: Long): Payee? {
+    db().query(DatabaseHelper.PAYEE_TABLE, null, "_id=?", arrayOf(id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return c.toPayee()
+    }
+    return null
+}
+
+@JvmName("getProject")
+fun MyEntityManager.getProject(id: Long): Project? {
+    db().query(DatabaseHelper.PROJECT_TABLE, null, "_id=?", arrayOf(id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return c.toProject()
+    }
+    return null
+}
+
+@JvmName("getLocation")
+fun MyEntityManager.getLocation(id: Long): MyLocation? {
+    db().query(DatabaseHelper.LOCATIONS_TABLE, null, "_id=?", arrayOf(id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return c.toMyLocation()
+    }
+    return null
+}
+
+@JvmName("getCategory")
+fun MyEntityManager.getCategory(id: Long): Category? {
+    db().query(DatabaseHelper.V_CATEGORY, DatabaseHelper.CategoryViewColumns.NORMAL_PROJECTION, "_id=?", arrayOf(id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return Category.formCursor(c)
+    }
+    return null
+}
+
+@JvmName("getCurrency")
+fun MyEntityManager.getCurrency(id: Long): Currency? {
+    db().query(DatabaseHelper.CURRENCY_TABLE, null, "_id=?", arrayOf(id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return c.toCurrency()
+    }
+    return null
+}
+
+@JvmName("getBudget")
+fun MyEntityManager.getBudget(id: Long): Budget? {
+    db().query(DatabaseHelper.BUDGET_TABLE, null, "_id=?", arrayOf(id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return c.toBudget(this)
+    }
+    return null
+}
+
+@JvmName("getSmsTemplate")
+fun MyEntityManager.getSmsTemplate(id: Long): SmsTemplate? {
+    db().query(DatabaseHelper.SMS_TEMPLATES_TABLE, DatabaseHelper.SmsTemplateColumns.NORMAL_PROJECTION, "_id=?", arrayOf(id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return SmsTemplate.fromCursor(c)
+    }
+    return null
+}
+
+@JvmName("getTransaction")
+fun MyEntityManager.getTransaction(id: Long): Transaction? {
+    db().query(DatabaseHelper.TRANSACTION_TABLE, null, "_id=?", arrayOf(id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return c.toTransaction()
+    }
+    return null
+}
+
+@JvmName("getTransactionInfo")
+fun MyEntityManager.getTransactionInfo(id: Long): TransactionInfo? {
+    db().query(DatabaseHelper.TRANSACTION_TABLE, null, "_id=?", arrayOf(id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return c.toTransactionInfo(this)
+    }
+    return null
+}
+
+// Saves
+
+fun MyEntityManager.getMaxSortOrder(tableName: String): Long {
+    db().rawQuery("SELECT max(sort_order) FROM $tableName", null).use { c ->
+        if (c.moveToFirst()) return c.getLong(0)
+    }
+    return 0L
+}
+
+@JvmName("saveAccount")
+fun MyEntityManager.saveAccount(account: Account): Long {
+    val cv = account.toValues()
+    cv.remove("updated_on")
+    cv.put("updated_on", System.currentTimeMillis())
+    return if (account.id > 0) {
+        db().update(DatabaseHelper.ACCOUNT_TABLE, cv, "_id=?", arrayOf(account.id.toString()))
+        account.id
+    } else {
+        cv.remove("_id")
+        if (account.sortOrder <= 0) {
+            account.sortOrder = (getMaxSortOrder(DatabaseHelper.ACCOUNT_TABLE) + 1).toInt()
+            cv.put("sort_order", account.sortOrder)
+        }
+        val id = db().insertOrThrow(DatabaseHelper.ACCOUNT_TABLE, null, cv)
+        account.id = id
+        id
+    }
+}
+
+@JvmName("savePayee")
+fun MyEntityManager.savePayee(payee: Payee): Long {
+    val cv = payee.toValues()
+    cv.remove("updated_on")
+    cv.put("updated_on", System.currentTimeMillis())
+    return if (payee.id > 0) {
+        db().update(DatabaseHelper.PAYEE_TABLE, cv, "_id=?", arrayOf(payee.id.toString()))
+        payee.id
+    } else {
+        cv.remove("_id")
+        if (payee.sortOrder <= 0) {
+            payee.sortOrder = getMaxSortOrder(DatabaseHelper.PAYEE_TABLE) + 1
+            cv.put("sort_order", payee.sortOrder)
+        }
+        val id = db().insertOrThrow(DatabaseHelper.PAYEE_TABLE, null, cv)
+        payee.id = id
+        id
+    }
+}
+
+@JvmName("saveProject")
+fun MyEntityManager.saveProject(project: Project): Long {
+    val cv = project.toValues()
+    cv.remove("updated_on")
+    cv.put("updated_on", System.currentTimeMillis())
+    return if (project.id > 0) {
+        db().update(DatabaseHelper.PROJECT_TABLE, cv, "_id=?", arrayOf(project.id.toString()))
+        project.id
+    } else {
+        cv.remove("_id")
+        if (project.sortOrder <= 0) {
+            project.sortOrder = getMaxSortOrder(DatabaseHelper.PROJECT_TABLE) + 1
+            cv.put("sort_order", project.sortOrder)
+        }
+        val id = db().insertOrThrow(DatabaseHelper.PROJECT_TABLE, null, cv)
+        project.id = id
+        id
+    }
+}
+
+@JvmName("saveLocation")
+fun MyEntityManager.saveLocation(location: MyLocation): Long {
+    val cv = location.toValues()
+    cv.remove("updated_on")
+    cv.put("updated_on", System.currentTimeMillis())
+    return if (location.id > 0) {
+        db().update(DatabaseHelper.LOCATIONS_TABLE, cv, "_id=?", arrayOf(location.id.toString()))
+        location.id
+    } else {
+        cv.remove("_id")
+        if (location.sortOrder <= 0) {
+            location.sortOrder = getMaxSortOrder(DatabaseHelper.LOCATIONS_TABLE) + 1
+            cv.put("sort_order", location.sortOrder)
+        }
+        val id = db().insertOrThrow(DatabaseHelper.LOCATIONS_TABLE, null, cv)
+        location.id = id
+        id
+    }
+}
+
+@JvmName("saveCategory")
+fun MyEntityManager.saveCategory(category: Category): Long {
+    val cv = ContentValues().apply {
+        put("title", category.title)
+        put("left", category.left)
+        put("right", category.right)
+        put("type", category.type)
+        put("last_location_id", category.lastLocationId)
+        put("last_project_id", category.lastProjectId)
+    }
+    return if (category.id > 0) {
+        db().update(DatabaseHelper.CATEGORY_TABLE, cv, "_id=?", arrayOf(category.id.toString()))
+        category.id
+    } else {
+        val id = db().insertOrThrow(DatabaseHelper.CATEGORY_TABLE, null, cv)
+        category.id = id
+        id
+    }
+}
+
+@JvmName("saveCurrency")
+fun MyEntityManager.saveCurrency(currency: Currency): Long {
+    val cv = currency.toValues()
+    cv.remove("updated_on")
+    cv.put("updated_on", System.currentTimeMillis())
+    return if (currency.id > 0) {
+        db().update(DatabaseHelper.CURRENCY_TABLE, cv, "_id=?", arrayOf(currency.id.toString()))
+        currency.id
+    } else {
+        cv.remove("_id")
+        if (currency.sortOrder <= 0) {
+            currency.sortOrder = getMaxSortOrder(DatabaseHelper.CURRENCY_TABLE) + 1
+            cv.put("sort_order", currency.sortOrder)
+        }
+        val id = db().insertOrThrow(DatabaseHelper.CURRENCY_TABLE, null, cv)
+        currency.id = id
+        id
+    }
+}
+
+@JvmName("saveBudget")
+fun MyEntityManager.saveBudget(budget: Budget): Long {
+    val cv = budget.toValues()
+    cv.remove("updated_on")
+    cv.put("updated_on", System.currentTimeMillis())
+    return if (budget.id > 0) {
+        db().update(DatabaseHelper.BUDGET_TABLE, cv, "_id=?", arrayOf(budget.id.toString()))
+        budget.id
+    } else {
+        cv.remove("_id")
+        if (budget.sortOrder <= 0) {
+            budget.sortOrder = getMaxSortOrder(DatabaseHelper.BUDGET_TABLE) + 1
+            cv.put("sort_order", budget.sortOrder)
+        }
+        val id = db().insertOrThrow(DatabaseHelper.BUDGET_TABLE, null, cv)
+        budget.id = id
+        id
+    }
+}
+
+@JvmName("saveSmsTemplate")
+fun MyEntityManager.saveSmsTemplate(smsTemplate: SmsTemplate): Long {
+    val cv = smsTemplate.toValues()
+    cv.remove("updated_on")
+    cv.put("updated_on", System.currentTimeMillis())
+    return if (smsTemplate.id > 0) {
+        db().update(DatabaseHelper.SMS_TEMPLATES_TABLE, cv, "_id=?", arrayOf(smsTemplate.id.toString()))
+        smsTemplate.id
+    } else {
+        cv.remove("_id")
+        if (smsTemplate.sortOrder <= 0) {
+            smsTemplate.sortOrder = getMaxSortOrder(DatabaseHelper.SMS_TEMPLATES_TABLE) + 1
+            cv.put("sort_order", smsTemplate.sortOrder)
+        }
+        val id = db().insertOrThrow(DatabaseHelper.SMS_TEMPLATES_TABLE, null, cv)
+        smsTemplate.id = id
+        id
+    }
+}
+
+@JvmName("insertOrUpdate")
+fun MyEntityManager.insertOrUpdate(transaction: Transaction): Long {
+    val cv = transaction.toValues()
+    cv.remove("updated_on")
+    cv.put("updated_on", System.currentTimeMillis())
+    return if (transaction.id > 0) {
+        db().update(DatabaseHelper.TRANSACTION_TABLE, cv, "_id=?", arrayOf(transaction.id.toString()))
+        transaction.id
+    } else {
+        cv.remove("_id")
+        val id = db().insertOrThrow(DatabaseHelper.TRANSACTION_TABLE, null, cv)
+        transaction.id = id
+        id
+    }
+}
+
+@JvmName("filterActiveEntities")
+fun MyEntityManager.filterActiveEntities(clazz: Class<*>, titleLike: String?): Cursor? {
+    val tableName = getTableName(clazz) ?: return null
+    var sql = "SELECT _id, title as e_title FROM $tableName WHERE is_active=1"
+    val args = mutableListOf<String>()
+    if (!titleLike.isNullOrBlank()) {
+        val cleanLike = titleLike.replace(" ", "%")
+        sql += " AND (title LIKE ? OR title LIKE ?)"
+        args.add("%$cleanLike%")
+        args.add("%${StringUtil.capitalize(cleanLike)}%")
+    }
+    sql += " ORDER BY title ASC"
+    return db().rawQuery(sql, args.toTypedArray())
+}
+
+@JvmName("getHomeCurrencyDirect")
+fun MyEntityManager.getHomeCurrencyDirect(): Currency {
+    db().query(DatabaseHelper.CURRENCY_TABLE, null, "is_default=1", null, null, null, null).use { c ->
+        if (c.moveToFirst()) return c.toCurrency()
+    }
+    return Currency.EMPTY
+}
+
+@JvmName("getAllScheduledTransactionsDirect")
+fun MyEntityManager.getAllScheduledTransactionsDirect(): ArrayList<TransactionInfo> {
+    val list = ArrayList<TransactionInfo>()
+    db().query(DatabaseHelper.TRANSACTION_TABLE, null, "is_template=2 AND parent_id=0", null, null, null, null).use { c ->
+        while (c.moveToNext()) {
+            list.add(c.toTransactionInfo(this))
+        }
+    }
+    return list
+}
+
+@JvmName("getSplitsForTransaction")
+fun MyEntityManager.getSplitsForTransaction(transactionId: Long): List<Transaction> {
+    val list = ArrayList<Transaction>()
+    db().query(DatabaseHelper.TRANSACTION_TABLE, null, "parent_id=?", arrayOf(transactionId.toString()), null, null, null).use { c ->
+        while (c.moveToNext()) {
+            list.add(c.toTransaction())
+        }
+    }
+    return list
+}
+
+@JvmName("getSplitsInfoForTransaction")
+fun MyEntityManager.getSplitsInfoForTransaction(transactionId: Long): List<TransactionInfo> {
+    val list = ArrayList<TransactionInfo>()
+    db().query(DatabaseHelper.TRANSACTION_TABLE, null, "parent_id=?", arrayOf(transactionId.toString()), null, null, null).use { c ->
+        while (c.moveToNext()) {
+            list.add(c.toTransactionInfo(this))
+        }
+    }
+    return list
+}
+
+@JvmName("getTransactionsForAccount")
+fun MyEntityManager.getTransactionsForAccount(accountId: Long): List<TransactionInfo> {
+    val list = ArrayList<TransactionInfo>()
+    db().query(DatabaseHelper.TRANSACTION_TABLE, null, "from_account_id=? AND parent_id=0", arrayOf(accountId.toString()), null, null, "datetime DESC").use { c ->
+        while (c.moveToNext()) {
+            list.add(c.toTransactionInfo(this))
+        }
+    }
+    return list
+}
+
+@JvmName("getAttributesForTransaction")
+fun MyEntityManager.getAttributesForTransaction(transactionId: Long): List<TransactionAttributeInfo> {
+    val list = ArrayList<TransactionAttributeInfo>()
+    db().query("V_TRANSACTION_ATTRIBUTES", null, "_id=? AND attribute_id>=0", arrayOf(transactionId.toString()), null, null, "attribute_name ASC").use { c ->
+        while (c.moveToNext()) {
+            list.add(c.toTransactionAttributeInfo())
+        }
+    }
+    return list
+}
+
+@JvmName("getSystemAttributeForTransaction")
+fun MyEntityManager.getSystemAttributeForTransaction(sa: SystemAttribute, transactionId: Long): TransactionAttributeInfo? {
+    db().query("V_TRANSACTION_ATTRIBUTES", null, "_id=? AND attribute_id=?", arrayOf(transactionId.toString(), sa.id.toString()), null, null, null).use { c ->
+        if (c.moveToFirst()) return c.toTransactionAttributeInfo()
+    }
+    return null
+}
+
+@JvmName("getAllAccountsCursor")
+fun MyEntityManager.getAllAccountsCursor(isActiveOnly: Boolean, includeAccounts: LongArray): Cursor {
+    val sortOrder = MyPreferences.getAccountSortOrder(context)
+    val selection = StringBuilder()
+    val selectionArgs = mutableListOf<String>()
+    
+    if (isActiveOnly) {
+        selection.append("is_active = 1")
+        if (includeAccounts.isNotEmpty()) {
+            selection.append(" OR _id IN (")
+            selection.append(includeAccounts.joinToString(",") { "?" })
+            selection.append(")")
+            includeAccounts.forEach { selectionArgs.add(it.toString()) }
+        }
+    }
+    
+    val orderBy = StringBuilder("is_active DESC, ")
+    val colName = when (sortOrder.property) {
+        "sortOrder" -> "sort_order"
+        "totalAmount" -> "total_amount"
+        else -> sortOrder.property
+    }
+    orderBy.append(colName).append(if (sortOrder.asc) " ASC" else " DESC")
+    orderBy.append(", title ASC")
+    
+    return db().query(
+        DatabaseHelper.ACCOUNT_TABLE,
+        null,
+        if (selection.isNotEmpty()) selection.toString() else null,
+        if (selectionArgs.isNotEmpty()) selectionArgs.toTypedArray() else null,
+        null,
+        null,
+        orderBy.toString()
+    )
+}

--- a/app/src/main/java/ru/orangesoftware/financisto/db/DatabaseMappers.kt
+++ b/app/src/main/java/ru/orangesoftware/financisto/db/DatabaseMappers.kt
@@ -254,7 +254,11 @@ fun Cursor.toTransactionInfo(em: MyEntityManager): TransactionInfo {
     val toAccountId = getLongSafe("to_account_id", getLongSafe("e_to_account_id", 0L))
     info.toAccount = if (toAccountId > 0) em.getAccount(toAccountId) else null
     val categoryId = getLongSafe("category_id", getLongSafe("e_category_id", 0L))
-    info.category = em.getCategory(categoryId) ?: Category.noCategory()
+    info.category = when (categoryId) {
+        0L -> Category.noCategory()
+        -1L -> Category.splitCategory()
+        else -> if (categoryId > 0) em.getCategory(categoryId) ?: Category.noCategory() else Category.noCategory()
+    }
     val projectId = getLongSafe("project_id", getLongSafe("e_project_id", 0L))
     info.project = if (projectId > 0) em.getProject(projectId) else null
     val locationId = getLongSafe("location_id", getLongSafe("e_location_id", 0L))
@@ -418,9 +422,14 @@ fun MyEntityManager.queryEntitiesCursor(
         selectionArgs.add("%$titleLike%")
         selectionArgs.add("%${StringUtil.capitalize(titleLike)}%")
     }
-    
     val order = sort?.takeIf { it.isNotEmpty() }?.joinToString(", ") { s ->
-        val col = if (s.field == "sortOrder" || s.field == "sort_order") "sort_order" else s.field
+        val col = when (s.field) {
+            "sortOrder", "sort_order" -> "sort_order"
+            "totalAmount", "total_amount" -> "total_amount"
+            "creationDate", "creation_date" -> "creation_date"
+            "lastTransactionDate", "last_transaction_date" -> "last_transaction_date"
+            else -> s.field
+        }
         "$col ${if (s.asc) "ASC" else "DESC"}"
     } ?: "title ASC"
     

--- a/app/src/main/java/ru/orangesoftware/financisto/db/DatabaseMappers.kt
+++ b/app/src/main/java/ru/orangesoftware/financisto/db/DatabaseMappers.kt
@@ -448,60 +448,114 @@ fun MyEntityManager.queryEntitiesCursor(
 
 fun MyEntityManager.getAccountsList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<Account> {
     val list = ArrayList<Account>()
+    var e0: Account? = null
     queryEntitiesCursor(DatabaseHelper.ACCOUNT_TABLE, include0, onlyActive, filter, sort).use { c ->
         while (c.moveToNext()) {
-            list.add(c.toAccount(this))
+            val e = c.toAccount(this)
+            if (e.id == 0L) {
+                e0 = e
+            } else {
+                list.add(e)
+            }
         }
+    }
+    if (e0 != null) {
+        list.add(0, e0)
     }
     return list
 }
 
 fun MyEntityManager.getPayeesList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<Payee> {
     val list = ArrayList<Payee>()
+    var e0: Payee? = null
     queryEntitiesCursor(DatabaseHelper.PAYEE_TABLE, include0, onlyActive, filter, sort).use { c ->
         while (c.moveToNext()) {
-            list.add(c.toPayee())
+            val e = c.toPayee()
+            if (e.id == 0L) {
+                e0 = e
+            } else {
+                list.add(e)
+            }
         }
+    }
+    if (e0 != null) {
+        list.add(0, e0)
     }
     return list
 }
 
 fun MyEntityManager.getProjectsList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<Project> {
     val list = ArrayList<Project>()
+    var e0: Project? = null
     queryEntitiesCursor(DatabaseHelper.PROJECT_TABLE, include0, onlyActive, filter, sort).use { c ->
         while (c.moveToNext()) {
-            list.add(c.toProject())
+            val e = c.toProject()
+            if (e.id == 0L) {
+                e0 = e
+            } else {
+                list.add(e)
+            }
         }
+    }
+    if (e0 != null) {
+        list.add(0, e0)
     }
     return list
 }
 
 fun MyEntityManager.getLocationsList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<MyLocation> {
     val list = ArrayList<MyLocation>()
+    var e0: MyLocation? = null
     queryEntitiesCursor(DatabaseHelper.LOCATIONS_TABLE, include0, onlyActive, filter, sort).use { c ->
         while (c.moveToNext()) {
-            list.add(c.toMyLocation())
+            val e = c.toMyLocation()
+            if (e.id == 0L) {
+                e0 = e
+            } else {
+                list.add(e)
+            }
         }
+    }
+    if (e0 != null) {
+        list.add(0, e0)
     }
     return list
 }
 
 fun MyEntityManager.getCategoriesList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<Category> {
     val list = ArrayList<Category>()
+    var e0: Category? = null
     queryEntitiesCursor(DatabaseHelper.CATEGORY_TABLE, include0, onlyActive, filter, sort).use { c ->
         while (c.moveToNext()) {
-            list.add(Category.formCursor(c))
+            val e = Category.formCursor(c)
+            if (e.id == 0L) {
+                e0 = e
+            } else {
+                list.add(e)
+            }
         }
+    }
+    if (e0 != null) {
+        list.add(0, e0)
     }
     return list
 }
 
 fun MyEntityManager.getCurrenciesList(include0: Boolean, onlyActive: Boolean, filter: String?, sort: Array<out Sort>?): ArrayList<Currency> {
     val list = ArrayList<Currency>()
+    var e0: Currency? = null
     queryEntitiesCursor(DatabaseHelper.CURRENCY_TABLE, include0, onlyActive, filter, sort).use { c ->
         while (c.moveToNext()) {
-            list.add(c.toCurrency())
+            val e = c.toCurrency()
+            if (e.id == 0L) {
+                e0 = e
+            } else {
+                list.add(e)
+            }
         }
+    }
+    if (e0 != null) {
+        list.add(0, e0)
     }
     return list
 }

--- a/app/src/main/java/ru/orangesoftware/financisto/db/MyEntityManager.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/db/MyEntityManager.java
@@ -296,7 +296,7 @@ public abstract class MyEntityManager extends EntityManager {
             if (currency.isDefault) {
                 db.execSQL(UPDATE_DEFAULT_FLAG);
             }
-            long id = super.saveOrUpdate(currency);
+            long id = DatabaseMappersKt.saveCurrency(this, currency);
             db.setTransactionSuccessful();
             return id;
         } finally {

--- a/app/src/main/java/ru/orangesoftware/financisto/db/MyEntityManager.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/db/MyEntityManager.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -31,12 +30,12 @@ import ru.orangesoftware.financisto.model.MyEntity;
 import ru.orangesoftware.financisto.model.MyLocation;
 import ru.orangesoftware.financisto.model.Payee;
 import ru.orangesoftware.financisto.model.Project;
+import ru.orangesoftware.financisto.model.SmsTemplate;
 import ru.orangesoftware.financisto.model.SystemAttribute;
 import ru.orangesoftware.financisto.model.Transaction;
 import ru.orangesoftware.financisto.model.TransactionAttributeInfo;
 import ru.orangesoftware.financisto.model.TransactionInfo;
 import ru.orangesoftware.financisto.utils.MyPreferences;
-import ru.orangesoftware.financisto.utils.MyPreferences.AccountSortOrder;
 import ru.orangesoftware.financisto.utils.MyPreferences.LocationsSortOrder;
 import ru.orangesoftware.financisto.utils.RecurUtils;
 import ru.orangesoftware.financisto.utils.RecurUtils.Recur;
@@ -57,7 +56,58 @@ public abstract class MyEntityManager extends EntityManager {
         this.context = context;
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(Class<T> clazz, Object id) {
+        if (id == null) {
+            throw new IllegalArgumentException("Id can't be null");
+        }
+        long entityId = (Long) id;
+        if (clazz == Account.class) return (T) DatabaseMappersKt.getAccount(this, entityId);
+        if (clazz == Payee.class) return (T) DatabaseMappersKt.getPayee(this, entityId);
+        if (clazz == Project.class) return (T) DatabaseMappersKt.getProject(this, entityId);
+        if (clazz == MyLocation.class) return (T) DatabaseMappersKt.getLocation(this, entityId);
+        if (clazz == Category.class) return (T) DatabaseMappersKt.getCategory(this, entityId);
+        if (clazz == Currency.class) return (T) DatabaseMappersKt.getCurrency(this, entityId);
+        if (clazz == Budget.class) return (T) DatabaseMappersKt.getBudget(this, entityId);
+        if (clazz == SmsTemplate.class) return (T) DatabaseMappersKt.getSmsTemplate(this, entityId);
+        if (clazz == Transaction.class) return (T) DatabaseMappersKt.getTransaction(this, entityId);
+        if (clazz == TransactionInfo.class) return (T) DatabaseMappersKt.getTransactionInfo(this, entityId);
+        return super.get(clazz, id);
+    }
+
+    @Override
+    public long saveOrUpdate(Object entity) {
+        if (entity == null) {
+            throw new IllegalArgumentException("Entity is null");
+        }
+        if (entity instanceof Account) return DatabaseMappersKt.saveAccount(this, (Account) entity);
+        if (entity instanceof Payee) return DatabaseMappersKt.savePayee(this, (Payee) entity);
+        if (entity instanceof Project) return DatabaseMappersKt.saveProject(this, (Project) entity);
+        if (entity instanceof MyLocation) return DatabaseMappersKt.saveLocation(this, (MyLocation) entity);
+        if (entity instanceof Category) return DatabaseMappersKt.saveCategory(this, (Category) entity);
+        if (entity instanceof Currency) return saveOrUpdate((Currency) entity);
+        if (entity instanceof Budget) return DatabaseMappersKt.saveBudget(this, (Budget) entity);
+        if (entity instanceof SmsTemplate) return DatabaseMappersKt.saveSmsTemplate(this, (SmsTemplate) entity);
+        if (entity instanceof Transaction) return DatabaseMappersKt.insertOrUpdate(this, (Transaction) entity);
+        return super.saveOrUpdate(entity);
+    }
+
+    @Override
+    public <T> int delete(Class<T> clazz, Object id) {
+        if (id == null) {
+            throw new IllegalArgumentException("Id can't be null");
+        }
+        String tableName = DatabaseMappersKt.getTableName(this, clazz);
+        if (tableName != null) {
+            return db().delete(tableName, "_id=?", new String[]{String.valueOf(id)});
+        }
+        return super.delete(clazz, id);
+    }
+
     public <T extends MyEntity> Cursor filterActiveEntities(Class<T> clazz, String titleLike) {
+        Cursor c = DatabaseMappersKt.filterActiveEntities(this, clazz, titleLike);
+        if (c != null) return c;
         return queryEntities(clazz, titleLike, false, true);
     }
 
@@ -88,7 +138,15 @@ public abstract class MyEntityManager extends EntityManager {
         return getAllEntitiesList(clazz, include0, onlyActive, null, sort);
     }
 
+    @SuppressWarnings("unchecked")
     public <T extends MyEntity> ArrayList<T> getAllEntitiesList(Class<T> clazz, boolean include0, boolean onlyActive, String filter, Sort... sort) {
+        if (clazz == Account.class) return (ArrayList<T>) DatabaseMappersKt.getAccountsList(this, include0, onlyActive, filter, sort);
+        if (clazz == Payee.class) return (ArrayList<T>) DatabaseMappersKt.getPayeesList(this, include0, onlyActive, filter, sort);
+        if (clazz == Project.class) return (ArrayList<T>) DatabaseMappersKt.getProjectsList(this, include0, onlyActive, filter, sort);
+        if (clazz == MyLocation.class) return (ArrayList<T>) DatabaseMappersKt.getLocationsList(this, include0, onlyActive, filter, sort);
+        if (clazz == Category.class) return (ArrayList<T>) DatabaseMappersKt.getCategoriesList(this, include0, onlyActive, filter, sort);
+        if (clazz == Currency.class) return (ArrayList<T>) DatabaseMappersKt.getCurrenciesList(this, include0, onlyActive, filter, sort);
+
         try (Cursor c = queryEntities(clazz, filter, include0, onlyActive, sort)) {
             T e0 = null;
             ArrayList<T> list = new ArrayList<>();
@@ -164,34 +222,11 @@ public abstract class MyEntityManager extends EntityManager {
     }
 
     public List<TransactionAttributeInfo> getAttributesForTransaction(long transactionId) {
-        Query<TransactionAttributeInfo> q = createQuery(TransactionAttributeInfo.class).asc("name");
-        q.where(Expressions.and(
-                Expressions.eq("transactionId", transactionId),
-                Expressions.gte("attributeId", 0)
-        ));
-        try (Cursor c = q.execute()) {
-            List<TransactionAttributeInfo> list = new LinkedList<>();
-            while (c.moveToNext()) {
-                TransactionAttributeInfo ti = loadFromCursor(c, TransactionAttributeInfo.class);
-                list.add(ti);
-            }
-            return list;
-        }
-
+        return DatabaseMappersKt.getAttributesForTransaction(this, transactionId);
     }
-
+ 
     public TransactionAttributeInfo getSystemAttributeForTransaction(SystemAttribute sa, long transactionId) {
-        Query<TransactionAttributeInfo> q = createQuery(TransactionAttributeInfo.class);
-        q.where(Expressions.and(
-                Expressions.eq("transactionId", transactionId),
-                Expressions.eq("attributeId", sa.getId())
-        ));
-        try (Cursor c = q.execute()) {
-            if (c.moveToFirst()) {
-                return loadFromCursor(c, TransactionAttributeInfo.class);
-            }
-            return null;
-        }
+        return DatabaseMappersKt.getSystemAttributeForTransaction(this, sa, transactionId);
     }
 
     /* ===============================================
@@ -221,28 +256,7 @@ public abstract class MyEntityManager extends EntityManager {
     }
 
     private Cursor getAllAccounts(boolean isActiveOnly, long... includeAccounts) {
-        AccountSortOrder sortOrder = MyPreferences.getAccountSortOrder(context);
-        Query<Account> q = createQuery(Account.class);
-        if (isActiveOnly) {
-            int count = includeAccounts.length;
-            if (count > 0) {
-                Expression[] ee = new Expression[count + 1];
-                for (int i = 0; i < count; i++) {
-                    ee[i] = Expressions.eq("id", includeAccounts[i]);
-                }
-                ee[count] = Expressions.eq("isActive", 1);
-                q.where(Expressions.or(ee));
-            } else {
-                q.where(Expressions.eq("isActive", 1));
-            }
-        }
-        q.desc("isActive");
-        if (sortOrder.asc) {
-            q.asc(sortOrder.property);
-        } else {
-            q.desc(sortOrder.property);
-        }
-        return q.asc("title").execute();
+        return DatabaseMappersKt.getAllAccountsCursor(this, isActiveOnly, includeAccounts);
     }
 
     public long saveAccount(Account account) {
@@ -253,7 +267,7 @@ public abstract class MyEntityManager extends EntityManager {
         List<Account> list = new ArrayList<>();
         try (Cursor c = getAllAccounts()) {
             while (c.moveToNext()) {
-                Account a = EntityManager.loadFromCursor(c, Account.class);
+                Account a = DatabaseMappersKt.toAccount(c, this);
                 list.add(a);
             }
         }
@@ -385,7 +399,7 @@ public abstract class MyEntityManager extends EntityManager {
                 budget.recurNum = i;
                 budget.startDate = p.getStart();
                 budget.endDate = p.getEnd();
-                long bid = super.saveOrUpdate(budget);
+                long bid = DatabaseMappersKt.saveBudget(this, budget);
                 if (i == 0) {
                     id = bid;
                 }
@@ -408,31 +422,32 @@ public abstract class MyEntityManager extends EntityManager {
     }
 
     public ArrayList<Budget> getAllBudgets(WhereFilter filter) {
-        Query<Budget> q = createQuery(Budget.class);
         Criteria c = filter.get(BlotterFilter.DATETIME);
+        String selection = null;
+        String[] selectionArgs = null;
         if (c != null) {
             long start = c.getLongValue1();
             long end = c.getLongValue2();
-            q.where(Expressions.and(Expressions.lte("startDate", end), Expressions.gte("endDate", start)));
-
-            switch (MyPreferences.getBudgetsSortOrder(context)) {
-                case DATE:
-                    q.desc("startDate");
-                    break;
-
-                case NAME:
-                    q.asc("title");
-                    break;
-
-                case AMOUNT:
-                    q.desc("amount");
-                    break;
-            }
+            selection = "start_date <= ? AND end_date >= ?";
+            selectionArgs = new String[] { String.valueOf(end), String.valueOf(start) };
         }
-        try (Cursor cursor = q.execute()) {
+        
+        String orderBy = "title ASC";
+        switch (MyPreferences.getBudgetsSortOrder(context)) {
+            case DATE:
+                orderBy = "start_date DESC";
+                break;
+            case NAME:
+                orderBy = "title ASC";
+                break;
+            case AMOUNT:
+                orderBy = "amount DESC";
+                break;
+        }
+        try (Cursor cursor = db().query(BUDGET_TABLE, null, selection, selectionArgs, null, null, orderBy)) {
             ArrayList<Budget> list = new ArrayList<>();
             while (cursor.moveToNext()) {
-                Budget b = MyEntityManager.loadFromCursor(cursor, Budget.class);
+                Budget b = DatabaseMappersKt.toBudget(cursor, this);
                 list.add(b);
             }
             return list;
@@ -454,11 +469,7 @@ public abstract class MyEntityManager extends EntityManager {
     }
 
     public ArrayList<TransactionInfo> getAllScheduledTransactions() {
-        Query<TransactionInfo> q = createQuery(TransactionInfo.class);
-        q.where(Expressions.and(
-                Expressions.eq("isTemplate", 2),
-                Expressions.eq("parentId", 0)));
-        return (ArrayList<TransactionInfo>) q.list();
+        return DatabaseMappersKt.getAllScheduledTransactionsDirect(this);
     }
 
     @Nullable
@@ -531,25 +542,15 @@ public abstract class MyEntityManager extends EntityManager {
     }
 
     public List<Transaction> getSplitsForTransaction(long transactionId) {
-        Query<Transaction> q = createQuery(Transaction.class);
-        q.where(Expressions.eq("parentId", transactionId));
-        return q.list();
+        return DatabaseMappersKt.getSplitsForTransaction(this, transactionId);
     }
 
     public List<TransactionInfo> getSplitsInfoForTransaction(long transactionId) {
-        Query<TransactionInfo> q = createQuery(TransactionInfo.class);
-        q.where(Expressions.eq("parentId", transactionId));
-        return q.list();
+        return DatabaseMappersKt.getSplitsInfoForTransaction(this, transactionId);
     }
 
     public List<TransactionInfo> getTransactionsForAccount(long accountId) {
-        Query<TransactionInfo> q = createQuery(TransactionInfo.class);
-        q.where(Expressions.and(
-                Expressions.eq("fromAccount.id", accountId),
-                Expressions.eq("parentId", 0)
-        ));
-        q.desc("dateTime");
-        return q.list();
+        return DatabaseMappersKt.getTransactionsForAccount(this, accountId);
     }
 
     void reInsertEntity(MyEntity e) {
@@ -559,13 +560,7 @@ public abstract class MyEntityManager extends EntityManager {
     }
 
     public Currency getHomeCurrency() {
-        Query<Currency> q = createQuery(Currency.class);
-        q.where(Expressions.eq("isDefault", "1")); //uh-oh
-        Currency homeCurrency = q.uniqueResult();
-        if (homeCurrency == null) {
-            homeCurrency = Currency.EMPTY;
-        }
-        return homeCurrency;
+        return DatabaseMappersKt.getHomeCurrencyDirect(this);
     }
 
     private static <T extends MyEntity> Map<String, T> entitiesAsTitleMap(List<T> entities) {

--- a/app/src/main/java/ru/orangesoftware/financisto/utils/CurrencyCache.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/utils/CurrencyCache.java
@@ -43,6 +43,10 @@ public class CurrencyCache {
 		return c != null ? c : Currency.EMPTY;
 	}
 
+	public static synchronized void clear() {
+		CURRENCIES.clear();
+	}
+
 	public static synchronized void initialize(EntityManager em) {
 		TLongObjectHashMap<Currency> currencies = new TLongObjectHashMap<>();
 		Query<Currency> q = em.createQuery(Currency.class);

--- a/app/src/main/java/ru/orangesoftware/financisto/utils/TransactionUtils.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/utils/TransactionUtils.java
@@ -23,19 +23,28 @@ import ru.orangesoftware.financisto.model.Project;
 
 public class TransactionUtils {
 
+	private static String getColumnName(Cursor cursor, String... possibleNames) {
+		for (String name : possibleNames) {
+			if (cursor.getColumnIndex(name) != -1) {
+				return name;
+			}
+		}
+		return possibleNames[0];
+	}
+
 	public static ListAdapter createAccountAdapter(Context context, Cursor accountCursor) {
 		return new SimpleCursorAdapter(context, android.R.layout.simple_spinner_dropdown_item, accountCursor, 
-				new String[]{"e_"+AccountColumns.TITLE}, new int[]{android.R.id.text1});		
+				new String[]{getColumnName(accountCursor, AccountColumns.TITLE, "e_" + AccountColumns.TITLE)}, new int[]{android.R.id.text1});		
 	}
 
     public static ListAdapter createAccountMultiChoiceAdapter(Context context, Cursor accountCursor) {
         return new SimpleCursorAdapter(context, android.R.layout.simple_list_item_multiple_choice, accountCursor,
-                new String[]{"e_"+AccountColumns.TITLE}, new int[]{android.R.id.text1});
+                new String[]{getColumnName(accountCursor, AccountColumns.TITLE, "e_" + AccountColumns.TITLE)}, new int[]{android.R.id.text1});
     }
 
 	public static SimpleCursorAdapter createCurrencyAdapter(Context context, Cursor currencyCursor) {
 		return new SimpleCursorAdapter(context, android.R.layout.simple_spinner_dropdown_item, currencyCursor, 
-				new String[]{"e_name"}, new int[]{android.R.id.text1});		
+				new String[]{getColumnName(currencyCursor, "name", "e_name")}, new int[]{android.R.id.text1});		
 	}
 
 	public static ListAdapter createCategoryAdapter(DatabaseAdapter db, Context context, Cursor categoryCursor) {
@@ -64,7 +73,7 @@ public class TransactionUtils {
 
     public static ListAdapter createLocationAdapter(Context context, Cursor cursor) {
 		return new SimpleCursorAdapter(context, android.R.layout.simple_spinner_dropdown_item, cursor, 
-				new String[]{"e_name"}, new int[]{android.R.id.text1});
+				new String[]{getColumnName(cursor, "name", "e_name", "title", "e_title")}, new int[]{android.R.id.text1});
 	}
 
     public static SimpleCursorAdapter createPayeeAutoCompleteAdapter(Context context, final MyEntityManager db) {

--- a/app/src/test/java/ru/orangesoftware/financisto/db/AbstractDbTest.java
+++ b/app/src/test/java/ru/orangesoftware/financisto/db/AbstractDbTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import android.Manifest;
 import android.app.Application;
 import android.content.Context;
-import android.content.Intent;
 import android.net.Uri;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -28,6 +27,7 @@ import ru.orangesoftware.financisto.model.Account;
 import ru.orangesoftware.financisto.model.Category;
 import ru.orangesoftware.financisto.model.Transaction;
 import ru.orangesoftware.financisto.test.DateTime;
+import ru.orangesoftware.financisto.utils.CurrencyCache;
 
 /**
  * Base class for database-related tests using Robolectric.
@@ -67,6 +67,7 @@ public abstract class AbstractDbTest {
         dbHelper = new DatabaseHelper(context);
         db = new TestDatabaseAdapter(context, dbHelper);
         db.open();
+        CurrencyCache.clear();
     }
 
     protected void registerFileForContentResolver(File file) throws Exception {


### PR DESCRIPTION
- Replace legacy reflection-based ORM loading with direct type-safe Kotlin DatabaseMappers in AccountListAdapter2, AccountWidget, and CurrencyListAdapter.
- Implement dynamic column prefix detection in TransactionUtils and QifImportActivity to support both direct database cursors (unprefixed) and legacy ORM cursors (prefixed with 'e_').
- Fix a regression where system entities (e.g. ID 0, -1) were not correctly inserted by restoreSystemEntities due to premature virtual object caching.
- Reset the static CurrencyCache in AbstractDbTest to prevent cross-test database and primary key contamination under Robolectric.
- Restore expected nullability mapping behaviors for Payee, Project, and MyLocation on Transactions.

Closes-Bug: #runtime-crashes
Test: ./gradlew test (all 289 unit tests pass successfully)